### PR TITLE
Cover card on the README player

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ force back into it, with every file needed to build one.
      inside a <div>. Do not wrap it in a <video> tag or in markdown link brackets, and do
      not swap it for a repo-relative path - GitHub's sanitiser strips <video> outright, and
      raw.githubusercontent serves .mp4 as application/octet-stream, so neither will play.
-     The same file is kept at docs/media/TAKTO-ONE.mp4 as the durable copy. -->
+     docs/media/TAKTO-ONE.mp4 is the durable in-repo copy. It is the same film without
+     the one-second cover card, which exists only so the player has a thumbnail; it is not
+     re-committed on each cover change, to keep binary churn out of git history. -->
 
-https://github.com/user-attachments/assets/8b99a291-4188-4111-b27c-68c6f68171b1
+https://github.com/user-attachments/assets/1538657f-96ee-4b98-8d4a-2e254e1aeca6
 
 ---
 


### PR DESCRIPTION
The player's thumbnail is the video's first frame, and the film opened on a near-black macro (mean luminance 20/255, 80% of pixels near black). So the cover had to go into the film itself.

A one-second title card in the film's own visual language, crossfading into the opening. Music and picture were rebuilt together — segment A now starts 1.0 s earlier in the track so the score runs continuously under the card, and all six event dips plus the seam shifted by exactly the same amount. Verified: the frame at 1.6 s matches the old 0.6 s frame at 60.6 dB PSNR.

**No new binary.** `docs/media/TAKTO-ONE.mp4` is not re-committed. Attachment uploads are hosted on GitHub's CDN and are not part of the repository, so swapping the player costs nothing, whereas another 9 MB blob would stay in git history permanently.