### PR TITLE
Better cover card on the README player

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ force back into it, with every file needed to build one.
      the one-second cover card, which exists only so the player has a thumbnail; it is not
      re-committed on each cover change, to keep binary churn out of git history. -->
 
-https://github.com/user-attachments/assets/1538657f-96ee-4b98-8d4a-2e254e1aeca6
+https://github.com/user-attachments/assets/484980ce-ec6d-4174-a04e-9c5ad102c8cc
 
 ---
 


### PR DESCRIPTION
Reworked cover.

**Frame.** Chosen by measuring twelve moments for peak highlight, true-black share, contrast and how calm each quadrant was. Winner is the fingers macro at 16.0 s (contrast 156, 30% true blacks, calm top-left). The highest-scoring frame overall, 18.8 s, was disqualified — it has burned-in caption text.

**Treatment.** No scrim. A filmic grade — black lift, gamma 1.28, gentle S-curve, off-centre vignette — so the encoder tabs read against genuinely deep shadow.

**Type.** Small, cornered, ultralight and widely tracked with a hairline rule, rather than a large centred title competing with the subject.

**Length.** 1.0 s down to **0.4 s** with a 0.3 s dissolve. Verified fully gone by 0.8 s (60.5 dB PSNR against pure film).

Score moved with the picture — measured on the final file: +10.6 dB start-to-peak preserved, lift at 15.608 s, drop −4.7 dB at 20.858 s. No new binary committed.